### PR TITLE
Use `advanced-issue-labeler` action for issue labeling

### DIFF
--- a/.github/workflows/Issue-text.yml
+++ b/.github/workflows/Issue-text.yml
@@ -4,9 +4,15 @@ on:
   issues:
     types: [opened]
 
+permissions:
+  contents: read
+
 jobs:
   comment:
     runs-on: ubuntu-latest
+
+    permissions:
+      issues: write
 
     steps:
     - uses: ben-z/actions-comment-on-issue@1.0.2
@@ -18,13 +24,12 @@ jobs:
       id: issue-parser
       with:
         template-path: .github/ISSUE_TEMPLATE/bug_report.yml
-        
-    - run: echo '${{ steps.issue-parser.outputs.jsonString }}'
-    
-    - run: echo ${{ steps.issue-parser.outputs.issueparser_what_browser_are_you_seeing_the_problem_on }}
-    
-    - uses: actions-ecosystem/action-add-labels@v1
+
+    - name: Set labels based on browsers field
+      uses: redhat-plumbers-in-action/advanced-issue-labeler@v1
       with:
-        labels: ${{ steps.issue-parser.outputs.issueparser_what_browser_are_you_seeing_the_problem_on }}
-        github_token: ${{ secrets.BOT }}
-        
+        issue-form: ${{ steps.issue-parser.outputs.jsonString }}
+        section: browsers
+        block-list: |
+          Other Browser
+        token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Similarly to https://github.com/blueedgetechno/win11React/pull/617

> Update `Issue-text.yml` to be more secure and use more suitable action.
>
> Instead of `actions-ecosystem/action-add-labels` action I added `redhat-plumbers-in-action/advanced-issue-labeler` action that is more suitable for use with issue forms. It provides so useful helpers to label issues based input provided via issue form.
>
> **Note**: I added the Other Browser option to the block list, so if the user chooses this option no label will be set. Do you prefer original behavior?